### PR TITLE
make column names case sensitive

### DIFF
--- a/src/main/java/com/github/lwhite1/tablesaw/table/Relation.java
+++ b/src/main/java/com/github/lwhite1/tablesaw/table/Relation.java
@@ -58,7 +58,7 @@ public interface Relation {
   default int columnIndex(String columnName) {
     int columnIndex = -1;
     for (int i = 0; i < columnCount(); i++) {
-      if (columnNames().get(i).equalsIgnoreCase(columnName)) {
+      if (columnNames().get(i).equals(columnName)) {
         columnIndex = i;
         break;
       }
@@ -75,7 +75,7 @@ public interface Relation {
   default Column column(String columnName) {
     Column result = null;
     for (Column column : columns()) {
-      if (column.name().equalsIgnoreCase(columnName)) {
+      if (column.name().equals(columnName)) {
         result = column;
         break;
       }


### PR DESCRIPTION
This bit me on my first usage of tablesaw.

I think we also should enforce uniqueness of column names in addColumn.  I think it should throw an exception if the name already exists.  Uniqueness is assumed and required in many places so I think it should be enforced.